### PR TITLE
fix localisation problems:

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -109,7 +109,7 @@ function RAW_Core:FindAllWarlocks()
 		-- Grab the raider info from the WOWAPI
 		local RaiderName, RaiderRank, RaiderSubgroup, RaiderLevel, RaiderClass, RaiderFileName, RaiderZone, RaiderOnline, RaiderIsDead, RaiderRole, RaidersIsML = GetRaidRosterInfo(Index);
 
-		if (RaiderClass == "Warlock") then
+		if (RaiderFileName == "WARLOCK") then
 
 			local bExists = false;
 
@@ -169,7 +169,7 @@ function RAW_Core:FindAllSoulstones()
 
 				local name, icon, count, debuffType, duration, expirationTime, source, isStealable, nameplateShowPersonal, spellId = UnitBuff(RaiderName,BuffIndex)
 
-				if name == "Soulstone Resurrection" then
+				if  spellId == 20707 or spellId == 20762 or spellId == 20763 or spellId == 20764 or spellId == 20765 then
 					local SoulstonedInfo = {}
 					-- Whos SSd
 					SoulstonedInfo.Name = RaiderName
@@ -187,7 +187,7 @@ function RAW_Core:FindAllSoulstones()
 					--SoulstonedInfo.ExperationTime = expirationTime
 
 					-- Class that was SSd
-					SoulstonedInfo.Class = RaiderClass
+					SoulstonedInfo.Class = RaiderFileName
 
 					-- Assign the updated info
 					RAW_Core.SoulstonedList[#RAW_Core.SoulstonedList+1] = SoulstonedInfo

--- a/EventHandler.lua
+++ b/EventHandler.lua
@@ -229,7 +229,7 @@ function RAW_EventHandler:Message_Raid(Channel, Message, Sender, arg11, arg12)
 				--Grab the raider info from the WOWAPI
 				local RaiderName, RaiderRank, RaiderSubgroup, RaiderLevel, RaiderClass, RaiderFileName, RaiderZone, RaiderOnline, RaiderIsDead, RaiderRole, RaidersIsML = GetRaidRosterInfo(Index);
 				if RaiderName == SummonName then
-					SummonInfo.Class = RaiderClass
+					SummonInfo.Class = RaiderFileName
 					SummonInfo.Zone = RaiderZone
 					SummonInfo.Online = RaiderOnline
 					SummonInfo.Dead = RaiderIsDead

--- a/Types.lua
+++ b/Types.lua
@@ -38,28 +38,28 @@ RAW.Types.SpellIcons =
 -- Class colours, used to Append to the start of a string to change the colour
 RAW.Types.ClassColours =
 {
-	["Druid"]	= "|cffFF7D0A",
-	["Hunter"]	= "|cffABD473",
-	["Mage"]	= "|cff40C7EB",
-	["Paladin"]	= "|cffF58CBA",
-	["Priest"]	= "|cffFFFFFF",
-	["Rogue"]	= "|cffFFF569",
-	["Shaman"]	= "|cff0070DE",
-	["Warlock"]	= "|cff8787ED",
-	["Warrior"]	= "|cffC79C6E",
+	["DRUID"]	= "|cffFF7D0A",
+	["HUNTER"]	= "|cffABD473",
+	["MAGE"]	= "|cff40C7EB",
+	["PALADIN"]	= "|cffF58CBA",
+	["PRIEST"]	= "|cffFFFFFF",
+	["ROUGE"]	= "|cffFFF569",
+	["SHAMAN"]	= "|cff0070DE",
+	["WARLOCK"]	= "|cff8787ED",
+	["WARRIOR"]	= "|cffC79C6E",
 }
 
 -- Class Icons, not actual class icons because there number doesnt appear to work in game
 RAW.Types.ClassIcons = 
 {
-	["Druid"]		= 136085,
-	["Warlock"]		= 136197,
-	["Paladin"]		= 135963,
-	["Mage"]		= 135846,
-	["Shaman"]		= 136048,
-	["Warrior"]		= 132355,
-	["Rogue"]		= 132320,
-	["Hunter"]		= 132222,
-	["Priest"]		= 135940,
+	["DRUID"]		= 136085,
+	["WARLOCK"]		= 136197,
+	["PALADIN"]		= 135963,
+	["MAGE"]		= 135846,
+	["SHAMAN"]		= 136048,
+	["WARRIOR"]		= 132355,
+	["ROUGE"]		= 132320,
+	["HUNTER"]		= 132222,
+	["PRIEST"]		= 135940,
 	["Unknown"]		= 132311,
 }


### PR DESCRIPTION
RaiderClass from GetRaidRosterInfo() and the Buff name "Soulstone Resurrection" is different on each language.
I have replace it by RaiderFileName and buff id.
RaiderFileName is on each language on english and all letters are uppercase

With this change the most is working on my german WoW client. 

One more problem will be the makro. It is only possible to use the name of a spell and this is on each language different. It is not possible to use a id... so we have to translate the string to all language that should work :(